### PR TITLE
Annoy Catalyst warnings

### DIFF
--- a/lib/Plack/Middleware/Debug/CatalystLog.pm
+++ b/lib/Plack/Middleware/Debug/CatalystLog.pm
@@ -23,7 +23,7 @@ sub run {
     return sub {
         my $res = shift;
 
-        my $log = delete $env->{'plack.middleware.catalyst_log'};
+        my $log = delete $env->{'plack.middleware.catalyst_log'} || 'No Log';
         $panel->content("<pre>$log</pre>");
         $psgi_env = undef;
     };


### PR DESCRIPTION
Using the Catalyst log (which I know needs more work but still) I get a lot of the following type warnings in my stdout/err:

Use of uninitialized value $log in concatenation (.) or string at /Users/johnn/mylocaltrials/lib/perl5/Plack/Middleware/Debug/CatalystLog.pm line 27, <DATA> line 46.

Looks like in the case where we don't have a log we still try to use it.  All this will need more work when the psgi version of Catalyst is fully baked but for now I think this tiny change is worth having, particularly now that people are using plack and cat more as we test code in support of the eventual psgi migration.

is just two lines of changes, please let me know if you want other changes as well.  Thanks@

John Napiorkowski
