### PR TITLE
Fix to Debug when multiple psgi apps in a process

### DIFF
--- a/lib/Plack/Middleware/Debug.pm
+++ b/lib/Plack/Middleware/Debug.pm
@@ -106,8 +106,10 @@ sub prepare_app {
             $builder->add_middleware("Debug::$package", @$spec);
         } else {
             # $spec could be a code ref (middleware) or a string
-            $spec = "Debug::$spec" unless ref $spec;
-            $builder->add_middleware($spec);
+            # copy so that we do not change default_panels
+            my $spec_copy = $spec;
+            $spec_copy = "Debug::$spec_copy" unless ref $spec_copy;
+            $builder->add_middleware($spec_copy);
         }
     }
 


### PR DESCRIPTION
When adding Debug::, make a copy so that we do not change default_panels, in case there are multiple apps in a process
