### PR TITLE
Allow BASE_URL to come from HTTP_X_REQUEST_BASE when SCRIPT_NAME is false

### DIFF
--- a/lib/Plack/Middleware/Debug.pm
+++ b/lib/Plack/Middleware/Debug.pm
@@ -145,7 +145,7 @@ sub call {
 
             my $vars = {
                 panels   => [ grep !$_->disabled, @$panels ],
-                BASE_URL => $env->{SCRIPT_NAME},
+                BASE_URL => $env->{SCRIPT_NAME} || $env->{HTTP_X_REQUEST_BASE},
             };
 
             my $content = $self->renderer->($vars);


### PR DESCRIPTION
For proxy deployments. I think this change is sane. Very lightly tested on my side.

Thank you very much, you are a great asset to Perl and web programming.

-Ashley
