### PR TITLE
Fixes abstract for Plack::Middleware::Debug::ModuleVersions

### DIFF
--- a/lib/Plack/Middleware/Debug/ModuleVersions.pm
+++ b/lib/Plack/Middleware/Debug/ModuleVersions.pm
@@ -18,7 +18,7 @@ __END__
 
 =head1 NAME
 
-Plack::Middleware::Debug::ModuleVersions - Debug panel to inspect the environment
+Plack::Middleware::Debug::ModuleVersions - Debug panel to inspect versions of loaded modules
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Looks like the original abstract was a copy/paste from Plack::Middleware::Debug::Environment
