### PR TITLE
fixed warnings

### DIFF
--- a/lib/Plack/Middleware/Debug/TrackObjects.pm
+++ b/lib/Plack/Middleware/Debug/TrackObjects.pm
@@ -1,6 +1,7 @@
 package Plack::Middleware::Debug::TrackObjects;
 use strict;
 use parent qw(Plack::Middleware::Debug::Base);
+use overload;
 
 sub run {
     my($self, $env, $panel) = @_;
@@ -14,12 +15,12 @@ sub run {
 
         my $track = Devel::TrackObjects->show_tracked_detailed;
         my @content;
-
+ 
         foreach (@$track){
-            if (length($_->[0]) > 100){
-                $_->[0] = substr($_->[0],0,100);
+            if (length(overload::StrVal($_->[0])) > 100){
+                $_->[0] = substr(overload::StrVal($_->[0]),0,100);
             }
-            push @content, $_->[0], $_->[1].' - '.$_->[2];
+            push @content, overload::StrVal($_->[0]), overload::StrVal($_->[1]).' - '.overload::StrVal($_->[2]);
         }
 
         $panel->nav_subtitle('Number:'.scalar(@content)/2);


### PR DESCRIPTION
I got this mail from the author of Devel::TrackObjects regarding strange warnings:

Hi, 

$tracked->[0] is the object itself.

If you print it it will stringify it. Stringification is overloaded
in Date::Time using Date::Time::_stringify, which will use ymd and hms
to stringify the object.

If the Date::Time object itself contains no $self->{local_c} yet the
values for sprintf in ymd and hms will be undef which causes the 
warnings.

So this is not really a bug in DateTime, because they never intended
for somebody to stringify some internal objects. But it's not a bug
in Devel::TrackObjects either.
Let's just say, they are not made to work close together.

But I've worked now around this overloading when debugging is enabled
(just released 0.5, see https://github.com/noxxi/p5-devel-trackobjects)
and so can you: 

```
+ use overload;
...
-      warn $tracked->[0];
+      warn overload::StrVal($tracked->[0]);
```
