### PR TITLE
Add the ability to load middleware outside Plack::Middleware::Debug::*

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Perl extension Plack-Middleware-Debug
 
 {{$NEXT}}
 
+    - Added support for loading debug middleware outside of the
+      Plack::Middleware::Debug::* namespace, by prefixing the name of
+      middleware with a "+",
+      e.g. "+My::Plack::Middleware::Debug::Something".
+
 0.16  2013-09-06 11:41:25 PDT
      - Merge with upstream
 

--- a/lib/Plack/Middleware/Debug.pm
+++ b/lib/Plack/Middleware/Debug.pm
@@ -103,12 +103,15 @@ sub prepare_app {
             # For the backward compatiblity
             # [ 'PanelName', key1 => $value1, ... ]
             $package = shift @$spec;
-            $builder->add_middleware("Debug::$package", @$spec);
+            $package = "Debug::$package" unless $package =~ /^\+/s;
+            $builder->add_middleware($package, @$spec);
         } else {
             # $spec could be a code ref (middleware) or a string
             # copy so that we do not change default_panels
             my $spec_copy = $spec;
-            $spec_copy = "Debug::$spec_copy" unless ref $spec_copy;
+            unless (ref $spec_copy) {
+                $spec_copy = "Debug::$spec_copy" unless $spec_copy =~ /^\+/s;;
+            }
             $builder->add_middleware($spec_copy);
         }
     }
@@ -205,8 +208,13 @@ Each panel specification can take one of three forms:
 =item A string
 
 This is interpreted as the base name of a panel in the
-C<Plack::Middeware::Debug::> namespace. The panel class is loaded and a panel
-object is created with its default settings.
+C<Plack::Middeware::Debug::> namespace, unless preceded by C<+>, in
+which case it's interpreted as an absolute name similar to how
+L<Plack::Builder> handles such names,
+e.g. C<+My::Plack::Middleware::Debug::Something>.
+
+The panel class is loaded and a panel object is created with its
+default settings.
 
 =item An array reference
 

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -5,6 +5,7 @@ use Plack::Test;
 use Plack::Builder;
 use HTTP::Request::Common;
 use Test::More;
+use lib "t/PlackX-Midldeware-Debug";
 my @content_types = ('text/html', 'text/html; charset=utf8',);
 for my $content_type (@content_types) {
     note "Content-Type: $content_type";
@@ -15,7 +16,7 @@ for my $content_type (@content_types) {
         ];
     };
     $app = builder {
-        enable 'Debug';
+        enable 'Debug', panels => [qw(Environment Response Timer Memory Session DBITrace +MiddlewareDebugTest)];
         $app;
     };
     test_psgi $app, sub {

--- a/t/PlackX-Midldeware-Debug/MiddlewareDebugTest.pm
+++ b/t/PlackX-Midldeware-Debug/MiddlewareDebugTest.pm
@@ -1,0 +1,17 @@
+package MiddlewareDebugTest;
+use 5.008;
+use strict;
+use warnings;
+use parent qw(Plack::Middleware::Debug::Base);
+
+sub run {
+    my ($self, $env, $panel) = @_;
+
+    return sub {
+        my $res = shift;
+
+        $panel->content( "Hello, world!" );
+    };
+}
+
+1;


### PR DESCRIPTION
It sucks that if you add some non-generic Middleware to your own
codebase that it needs to live in the Plack::Middleware::Debug::*
namespace. This patch trivially adjusts the prepare_app() loader so
we'll support +-prefixed middleware names like Plack::Builder.
