### PR TITLE
The Parameters panel seems to break POSTs in certain situations.

### DIFF
--- a/lib/Plack/Middleware/Debug/Parameters.pm
+++ b/lib/Plack/Middleware/Debug/Parameters.pm
@@ -13,20 +13,23 @@ sub prepare_app {
 
 sub run {
     my ( $self, $env, $panel ) = @_;
-    return sub {
-        my $parameters;
-        my $request = Plack::Request->new($env);
 
-        $parameters = {
+    my $content = do{
+        my $request = Plack::Request->new($env);
+        my $parameters = {
             get     => $request->query_parameters,
             cookies => $request->cookies,
             post    => $request->body_parameters,
             session => $env->{'psgix.session'},
             headers => $request->headers,
         };
+        $self->render_hash( $parameters, $self->elements );
+    };
+
+    return sub {
         $panel->title('Request Variables');
         $panel->nav_title('Request Variables');
-        $panel->content($self->render_hash( $parameters, $self->elements ));
+        $panel->content($content);
     }
 }
 


### PR DESCRIPTION
I've got Plack::Middleware::Debug wrapped around my Catalyst app and when I do a POST I get this error:

Bad Content-Length: maybe client disconnect? (120 bytes remaining) at /usr/local/share/perl/5.14.2/Plack/Request.pm line 286.

I was able to narrow this down to the Parameters panel, and further to the "post" element.  I was also able to find someone else with this issue:

http://tickets.musicbrainz.org/browse/MBS-4499

This fix bypasses the issue.  I do not know _why_ retrieving the request body in the run callback fails, but I'm guessing Catalyst is doing something to invalidate the body.
