### PR TITLE
Format values

### DIFF
--- a/lib/Plack/Middleware/Debug/Base.pm
+++ b/lib/Plack/Middleware/Debug/Base.pm
@@ -117,7 +117,7 @@ my $list_template = __PACKAGE__->build_template(<<'EOTMPL');
 % my($key, $value) = splice(@{$_[0]->{list}}, 0, 2);
             <tr class="<%= ++$i % 2 ? 'plDebugOdd' : 'plDebugEven' %>">
                 <td><%= $key %></td>
-                <td><%= vardump($value) %></td>
+                <td><pre><%= vardump($value) %></pre></td>
             </tr>
 % }
     </tbody>

--- a/lib/Plack/Middleware/Debug/Base.pm
+++ b/lib/Plack/Middleware/Debug/Base.pm
@@ -5,7 +5,7 @@ use warnings;
 use parent qw(Plack::Middleware);
 use Plack::Util::Accessor qw(renderer);
 use Text::MicroTemplate;
-use Data::Dump;
+use Data::Dumper::Concise;
 use Scalar::Util;
 
 our $VERSION = '0.16';
@@ -59,7 +59,7 @@ sub vardump {
     my $scalar = shift;
     return '(undef)' unless defined $scalar;
     return "$scalar" unless ref $scalar;
-    scalar Data::Dump::dump($scalar);
+    return scalar Dumper( $scalar );
 }
 
 sub build_template {


### PR DESCRIPTION
Just trying to make the debug panels a little easier to read when it comes to hashes.

Before:
<img width="782" alt="screenshot 2015-08-19 14 54 34" src="https://cloud.githubusercontent.com/assets/96205/9366051/ff47f784-4682-11e5-8d4b-591525070987.png">

After:
<img width="722" alt="screenshot 2015-08-19 14 58 27" src="https://cloud.githubusercontent.com/assets/96205/9366065/0e6cd16c-4683-11e5-8b30-db5e9b38142f.png">


.