### PR TITLE
Reduce negative text-indent of close button

### DIFF
--- a/share/debug_toolbar/toolbar.css
+++ b/share/debug_toolbar/toolbar.css
@@ -277,7 +277,7 @@
 */
 
 #plDebug .panelContent .plDebugClose {
-	text-indent:-9999999px;
+	text-indent:-999999px;
 	display:block;
 	position:absolute;
 	top:4px;


### PR DESCRIPTION
Matches the other similar negative text-indent, and prevents a strange vertical line in Chrome 60.

![image](https://user-images.githubusercontent.com/154364/29913501-4b2cff66-8e2d-11e7-85a0-a2877df3f6dc.png)
