### PR TITLE
Remove jQuery sourcing workaround.

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ Revision history for Perl extension Plack-Middleware-Debug
       Plack::Middleware::Debug::* namespace, by prefixing the name of
       middleware with a "+",
       e.g. "+My::Plack::Middleware::Debug::Something".
+    - Debug.pm no longer injects inline JavaScript
 
 0.16  2013-09-06 11:41:25 PDT
      - Merge with upstream

--- a/lib/Plack/Middleware/Debug.pm
+++ b/lib/Plack/Middleware/Debug.pm
@@ -18,20 +18,8 @@ use Try::Tiny;
 sub TEMPLATE {
     <<'EOTMPL' }
 % my $stash = $_[0];
-<script type="text/javascript" charset="utf-8">
-    // When jQuery is sourced, it's going to overwrite whatever might be in the
-    // '$' variable, so store a reference of it in a temporary variable...
-    var _$ = window.$;
-    if (typeof jQuery == 'undefined') {
-        var jquery_url = '<%= $stash->{BASE_URL} %>/debug_toolbar/jquery.js';
-        document.write(unescape('%3Cscript src="' + jquery_url + '" type="text/javascript"%3E%3C/script%3E'));
-    }
-</script>
-<script type="text/javascript" src="<%= $stash->{BASE_URL} %>/debug_toolbar/toolbar.min.js"></script>
-<script type="text/javascript" charset="utf-8">
-    // Now that jQuery is done loading, put the '$' variable back to what it was...
-    var $ = _$;
-</script>
+<script src="<%= $stash->{BASE_URL} %>/debug_toolbar/jquery.js"></script>
+<script src="<%= $stash->{BASE_URL} %>/debug_toolbar/toolbar.min.js"></script>
 <style type="text/css">
     @import url(<%= $stash->{BASE_URL} %>/debug_toolbar/toolbar.min.css);
 </style>


### PR DESCRIPTION
This should already be covered by the use of  `jQuery.noConflict()`.

The background is that at $work we've implemented a CSP (Content Security Policy) which warns on inline JS.  This means that enabling the debug panels triggers warnings.  Removing the `$` workaround from Debug.pm fixes this.

My JS understanding is limited, but it seems to me that this workaround is doing the same thing which `jQuery.noConflict()` does.  Since both the workaround and the `jQuery.noConflict()` call are in the initial repository commit, I can't easily tell if the workaround solves a specific problem or is just left over from before the use of `jQuery.noConflict()`.

If this is not the correct fix, I'm happy to look into implementing another approach.