### PR TITLE
Make test dependency explicit

### DIFF
--- a/META.json
+++ b/META.json
@@ -53,6 +53,7 @@
       },
       "test" : {
          "requires" : {
+            "Plack::Test" : "0",
             "Test::More" : "0.70",
             "Test::Requires" : "0.08"
          }

--- a/cpanfile
+++ b/cpanfile
@@ -9,6 +9,7 @@ requires 'parent';
 requires 'perl', '5.008001';
 
 on test => sub {
+    requires 'Plack::Test';
     requires 'Test::More', '0.70';
     requires 'Test::Requires', '0.08';
 };


### PR DESCRIPTION
On CentOS 7 you can install Plack using `yum install perl-Plack`, but you don't get everything installed that you'd get with `cpanm Plack`. In particular you don't get Plack::Test which has been separated into its own package (perl-Plack-Test).

Plack::Middleware::Debug declares a run-time dependency on Plack, assuming Plack::Test to be provided for test-time by the same distribution, but this does not always hold. I.e. if you `cpanm Plack::Middleware::Debug` when you have perl-Plack but not perl-Plack-Test installed, the test-time dependency on Plack:::Test won't be satisfied. 

I'm proposing to explicitly declare Plack::Test as a test-time dependency to Plack::Middleware::Debug. That way `cpanm` will notice if Plack::Test is missing and pick it up from CPAN. This isn't a perfect solution. Behind the scenes, along with Plack::Test `cpanm` would install a newer version of Plack, just waiting to surprise the unsuspecting users.