### PR TITLE
Add 'exclude_jquery' argument

### DIFF
--- a/lib/Plack/Middleware/Debug.pm
+++ b/lib/Plack/Middleware/Debug.pm
@@ -18,7 +18,9 @@ use Try::Tiny;
 sub TEMPLATE {
     <<'EOTMPL' }
 % my $stash = $_[0];
+% unless ($stash->{exclude_jquery}) {
 <script src="<%= $stash->{BASE_URL} %>/debug_toolbar/jquery.js"></script>
+% }
 <script src="<%= $stash->{BASE_URL} %>/debug_toolbar/toolbar.min.js"></script>
 <style type="text/css">
     @import url(<%= $stash->{BASE_URL} %>/debug_toolbar/toolbar.min.css);
@@ -135,8 +137,9 @@ sub call {
             && ($headers->get('Content-Type') || '') =~ m!^(?:text/html|application/xhtml\+xml)!) {
 
             my $vars = {
-                panels   => [ grep !$_->disabled, @$panels ],
-                BASE_URL => $env->{SCRIPT_NAME},
+                panels         => [ grep !$_->disabled, @$panels ],
+                exclude_jquery => $self->{'exclude_jquery'} // 0,
+                BASE_URL       => $env->{SCRIPT_NAME},
             };
 
             my $content = $self->renderer->($vars);
@@ -315,6 +318,20 @@ C<render_list_pairs()> method to place the pairs in the order we
 want. There is also a C<render_hash()> and C<render_lines()> method,
 to render a hash keys and values, as well as just text lines (e.g. log
 messages).
+
+=head1 EXCLUDING JQUERY
+
+By defualt L<Plack::Middleware::Debug> loads its own copy of jQuery. This
+can cause complications while debugging pages that have already loaded
+jQuery, or that load additional JavaScript files and jQuery plugins after
+the page has initially finished loading.  To indicate an existing jQuery
+should be used instead, the optional argument C<exclude_jquery> can be set
+to '1':
+
+    builder {
+        enable 'Debug', exclude_jquery => 1;
+        $app;
+    };
 
 =head1 BUGS AND LIMITATIONS
 

--- a/t/02_exclude_jquery.t
+++ b/t/02_exclude_jquery.t
@@ -1,0 +1,49 @@
+#!/usr/bin/env perl
+use warnings;
+use strict;
+use Plack::Test;
+use Plack::Builder;
+use HTTP::Request::Common;
+use Test::More;
+use lib "t/PlackX-Midldeware-Debug";
+
+my $app = sub {
+    return [
+        200, [ 'Content-Type' => 'text/html' ],
+        ['<body>Hello World</body>']
+    ];
+};
+
+# Default has jQuery
+test_psgi builder {
+    enable 'Debug';
+    $app;
+}, \&has_jquery;
+
+# jQuery excluded
+test_psgi builder {
+    enable 'Debug', exclude_jquery => 1;
+    $app;
+}, \&no_jquery;
+
+# jQuery implicitly included
+test_psgi builder {
+    enable 'Debug', exclude_jquery => 0;
+    $app;
+}, \&has_jquery;
+
+sub has_jquery {
+    my $cb  = shift;
+    my $res = $cb->(GET '/');
+    is $res->code, 200, 'response status 200';
+    like $res->content, qr/jquery\.js/, "HTML includes jQuery";
+}
+
+sub no_jquery {
+    my $cb  = shift;
+    my $res = $cb->(GET '/');
+    is $res->code, 200, 'response status 200';
+    unlike $res->content, qr/jquery\.js/, "HTML excludes jQuery";
+}
+
+done_testing;


### PR DESCRIPTION
    Because Plack::Middleware::Debug includes an older version of jQuery and
    loads into the page by replacing the closing `</body>` tag, any existing
    jQuery object is replaced.  This is somewhat mitigated by using
    `jQuery.noConflict();` in `toolbar.js`, but still results in
    'window.jQuery' referencing the older `1.2.6` version of jQuery that is
    loaded from `debug_toolbar/jquery.js`.
    
    If jQuery plugins were added prior to `debug_toolbar/jquery.js`, then
    they are no longer available under `window.jQuery` afterwards, as
    `noConflict()` simply restores the reference `$` previously pointed to,
    and the variable `jQuery` continues to point to the `1.2.6` version.
    
    This can also cause problems for code executed via `$(document).ready()`
    functions that reference `jQuery` (rather than `$`) when calling modern
    methods that are not available in the older `1.2.6` version of jQuery.
    
    A longer term solution would be to rewrite `toolbar.js` to remove its
    dependence on jQuery, but this small change to add 'exclude_jquery'
    makes it easy to work around the problem in the meantime.
